### PR TITLE
Add tilde escaping to resolve strikethrough issue in token identifier prefix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ string token = token.Token;
 ```
 
 ### Specifying token identifier prefix
-A prefix for the token identifier can optionally be provided to restrict the user session after getting through the queue to the one used before entering the queue. Once the user is through the queue the token identifier is provided to the target application in the Known User token. The format of the token identifier is then "[YOUR PREFIX]~[GUID]", e.g: AnfTDnpwazllYmnmgaCJ8tErV80YHv77ni5NgqQNhfWwxNqrNcHb~e937ef0d-48ec-4ff7-866e-52033273cb3d.
+A prefix for the token identifier can optionally be provided to restrict the user session after getting through the queue to the one used before entering the queue. Once the user is through the queue the token identifier is provided to the target application in the Known User token. The format of the token identifier is then "[YOUR PREFIX]\~[GUID]", e.g: AnfTDnpwazllYmnmgaCJ8tErV80YHv77ni5NgqQNhfWwxNqrNcHb\~e937ef0d-48ec-4ff7-866e-52033273cb3d.
 ```
 var tokenIdentifierPrefix = "AnfTDnpwazllYmnmgaCJ8tErV80YHv77ni5NgqQNhfWwxNqrNcHb";
 var token = Token


### PR DESCRIPTION
Fix strikethrough problem in token identifier prefix documentation